### PR TITLE
Update text describing off nadir vs. incidence angle

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,9 @@ The fields in the table below can be used in these parts of STAC documents:
 The angles `off_nadir`, `incidence_angle`, and `sun_elevation` are angles measured on a 2d plane formed: sensor location, 
 sub-sensor point on the earth, the sun, and the center of the viewed area.
 
-The off-nadir angle and the incidence angle are related. When the off-nadir angle is low (high incidence angle) then the 
-two angles sum to about 90, so one can be calculated from the other. However, at high off-nadir angles with high altitude 
-sensors the curvature of the earth has an impact and their sum will be less than 90. If only providing one of the two angles, 
-the off-nadir angle is preferred.
+The off-nadir angle and the incidence angle are related. When the off-nadir angle is low (low incidence angle) then the 
+two angles are approximately equal. However, at high off-nadir angles with high altitude sensors the curvature of the earth
+has an impact and the two angles are no longer equivalent. If only providing one of the two angles, the off-nadir angle is preferred.
 
 The angles `azimuth` and `sun_azimuth` indicate the position of the viewed scene and the sun by the angle from true north, as shown below.
 


### PR DESCRIPTION
The text describing how off-nadir and incidence angle are related appears to be referring to elevation instead - when off-nadir is low, elevation is high, but incidence angle is low.

Reword the section to state that off-nadir angle and incidence are approximately equal at low values, but not at high values.