### PR TITLE
Support assets, update extension generally

### DIFF
--- a/.github/remark.yaml
+++ b/.github/remark.yaml
@@ -1,4 +1,6 @@
 plugins:
+# GitHub Flavored Markdown
+  - remark-gfm
 # Check links
   - validate-links
 # Apply some recommended defaults for consistency
@@ -8,6 +10,7 @@ plugins:
 # General formatting
   - - remark-lint-emphasis-marker
     - '*'
+  - remark-lint-no-undefined-references
   - remark-lint-hard-break-spaces
   - remark-lint-blockquote-indentation
   - remark-lint-no-consecutive-blank-lines
@@ -37,7 +40,7 @@ plugins:
   - - remark-lint-unordered-list-marker-style
     - '-'
   - - remark-lint-list-item-indent
-    - space 
+    - space
 # Tables
   - remark-lint-table-pipes
   - remark-lint-no-literal-urls

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,12 @@
-/package-lock.json
-/node_modules
+# OS files
+.DS_Store
+Thumbs.db
+
+# Editors
+/.idea/
+/.vscode/
+
+# Node / npm
+.npm
+/node_modules/
+package-lock.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Updated schema to the latest version of the template
+- Allow fields in assets
+- Don't require a field in Item Properties if it is provided in other places (e.g. assets)
+
 ### Deprecated
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -22,21 +22,20 @@ extensions that describe the actual data, such as the `eo`, `sat` or `sar` exten
 ## Fields
 
 The fields in the table below can be used in these parts of STAC documents:
+
 - [ ] Catalogs
 - [ ] Collections
 - [x] Item Properties (incl. Summaries in Collections)
 - [x] Assets (for both Collections and Items, incl. Item Asset Definitions in Collections)
 - [ ] Links
 
-| Field Name           | Type                     | Description |
-| -------------------- | ------------------------ | ----------- |
-| view:off_nadir       | number               | The angle from the sensor between nadir (straight down) and the scene center. Measured in degrees (0-90). |
-| view:incidence_angle | number               | The incidence angle is the angle between the vertical (normal) to the intercepting surface and the line of sight back to the satellite at the scene center. Measured in degrees (0-90). |
-| view:azimuth         | number               | Viewing azimuth angle. The angle measured from the sub-satellite point (point on the ground below the platform) between the scene center and true north. Measured clockwise from north in degrees (0-360). |
-| view:sun_azimuth     | number               | Sun azimuth angle. From the scene center point on the ground, this is the angle between truth north and the sun. Measured clockwise in degrees (0-360). |
-| view:sun_elevation   | number               | Sun elevation angle. The angle from the tangent of the scene center point to the sun. Measured from the horizon in degrees (`-90`-`90`). Negative values indicate the sun is below the horizon, e.g. sun elevation of -10° means the data was captured during [nautical twilight](https://www.timeanddate.com/astronomy/different-types-twilight.html). |
-
-*At least one of the fields must be specified.*
+| Field Name           | Type   | Description |
+| -------------------- | ------ | ----------- |
+| view:off_nadir       | number | The angle from the sensor between nadir (straight down) and the scene center. Measured in degrees (0-90). |
+| view:incidence_angle | number | The incidence angle is the angle between the vertical (normal) to the intercepting surface and the line of sight back to the satellite at the scene center. Measured in degrees (0-90). |
+| view:azimuth         | number | Viewing azimuth angle. The angle measured from the sub-satellite point (point on the ground below the platform) between the scene center and true north. Measured clockwise from north in degrees (0-360). |
+| view:sun_azimuth     | number | Sun azimuth angle. From the scene center point on the ground, this is the angle between truth north and the sun. Measured clockwise in degrees (0-360). |
+| view:sun_elevation   | number | Sun elevation angle. The angle from the tangent of the scene center point to the sun. Measured from the horizon in degrees (`-90`-`90`). Negative values indicate the sun is below the horizon, e.g. sun elevation of -10° means the data was captured during [nautical twilight](https://www.timeanddate.com/astronomy/different-types-twilight.html). |
 
 The angles `off_nadir`, `incidence_angle`, and `sun_elevation` are angles measured on a 2d plane formed: sensor location, 
 sub-sensor point on the earth, the sun, and the center of the viewed area.
@@ -49,9 +48,10 @@ the off-nadir angle is preferred.
 The angles `azimuth` and `sun_azimuth` indicate the position of the viewed scene and the sun by the angle from true north, as shown below.
 
 Example:
+
 ```js
 {
-  "stac_version": "1.0.0-rc.1",
+  "stac_version": "1.1.0",
   "stac_extensions": [
     "https://stac-extensions.github.io/view/v1.0.0/schema.json"
   ],
@@ -71,22 +71,22 @@ Example:
 }
 ```
 
-## Best Practices
+## Asset Roles
 
-One of the emerging best practices is to use [Asset Roles](https://github.com/radiantearth/stac-spec/tree/master/item-spec/item-spec.md#asset-roles)
+One of the best practices is to use [Asset Roles](https://github.com/radiantearth/stac-spec/tree/master/item-spec/item-spec.md#asset-roles)
 to provide clients with more information about the assets in an item. The following list includes a shared vocabulary for some common EO assets. 
 This list should not be considered definitive, and implementors are welcome to use other asset roles. If consensus and tooling consolidates around
 these role names then they will be specified in the future as more standard than just 'best practices'. The roles listed below
 all tend to be additional files that contain specific values for every single pixel. It is recommended to use them all with the role of 'metadata'.
 
-| Role Name | Description                                                            |
-| --------- | ---------------------------------------------------------------------- |
-| incidence-angle | Points to a file with per-pixel incidence angles. |
-| azimuth | Points to a file with per-pixel azimuth angles. |
-| sun-azimuth | Points to a file with per-pixel sun azimuth angles. |
-| sun-elevation | Points to a file with per-pixel sun elevation angles. |
-| terrain-shadow | Points to a file that indicates whether a pixel is not directly illuminated due to terrain shadowing. |
-| terrain-occlusion | Points to a file that indicates whether a pixel is not visible to the sensor due to terrain occlusion during off-nadir viewing. |
+| Role Name            | Description |
+| -------------------- | ----------- |
+| incidence-angle      | Points to a file with per-pixel incidence angles. |
+| azimuth              | Points to a file with per-pixel azimuth angles. |
+| sun-azimuth          | Points to a file with per-pixel sun azimuth angles. |
+| sun-elevation        | Points to a file with per-pixel sun elevation angles. |
+| terrain-shadow       | Points to a file that indicates whether a pixel is not directly illuminated due to terrain shadowing. |
+| terrain-occlusion    | Points to a file that indicates whether a pixel is not visible to the sensor due to terrain occlusion during off-nadir viewing. |
 | terrain-illumination | Points to a file with coefficients used for terrain illumination correction are provided for each pixel. |
 
 ## Contributing

--- a/examples/item.json
+++ b/examples/item.json
@@ -1,5 +1,5 @@
 {
-  "stac_version": "1.0.0-rc.1",
+  "stac_version": "1.1.0",
   "stac_extensions": [
     "https://stac-extensions.github.io/view/v1.0.0/schema.json"
   ],

--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -1,100 +1,113 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://stac-extensions.github.io/view/v1.0.0/schema.json#",
+  "$id": "https://stac-extensions.github.io/view/v1.0.0/schema.json",
   "title": "View Geometry Extension",
-  "description": "STAC View Geometry Extension for STAC Items and STAC Collections.",
+  "description": "STAC View Geometry for STAC Items and STAC Collections.",
+  "type": "object",
+  "required": ["stac_extensions"],
+  "properties": {
+    "stac_extensions": {
+      "type": "array",
+      "contains": {
+        "const": "https://stac-extensions.github.io/view/v1.0.0/schema.json"
+      }
+    }
+  },
   "oneOf": [
     {
       "$comment": "This is the schema for STAC Items.",
-      "allOf": [
+      "type": "object",
+      "required": ["type"],
+      "properties": {
+        "type": {
+          "const": "Feature"
+        }
+      },
+      "anyOf": [
         {
-          "type": "object",
-          "required": [
-            "type",
-            "properties",
-            "assets"
-          ],
+          "required": ["properties"],
           "properties": {
-            "type": {
-              "const": "Feature"
-            },
             "properties": {
-              "allOf": [
-                {
-                  "anyOf": [
-                    {"required": ["view:off_nadir"]},
-                    {"required": ["view:incidence_angle"]},
-                    {"required": ["view:azimuth"]},
-                    {"required": ["view:sun_azimuth"]},
-                    {"required": ["view:sun_elevation"]}
-                  ]
-                },
-                {
-                  "$ref": "#/definitions/fields"
-                }
-              ]
-            },
-            "assets": {
-              "type": "object",
-              "additionalProperties": {
-                "$ref": "#/definitions/fields"
-              }
+              "$ref": "#/definitions/requirements_and_fields"
             }
           }
         },
         {
-          "$ref": "#/definitions/stac_extensions"
+          "$ref": "#/definitions/assets"
         }
       ]
     },
     {
       "$comment": "This is the schema for STAC Collections.",
-      "allOf": [
+      "type": "object",
+      "required": ["type"],
+      "properties": {
+        "type": {
+          "const": "Collection"
+        }
+      },
+      "anyOf": [
         {
-          "type": "object",
-          "required": [
-            "type"
-          ],
+          "$ref": "#/definitions/assets"
+        },
+        {
+          "required": ["item_assets"],
           "properties": {
-            "type": {
-              "const": "Collection"
-            },
-            "assets": {
-              "type": "object",
-              "additionalProperties": {
-                "$ref": "#/definitions/fields"
-              }
-            },
             "item_assets": {
-              "type": "object",
-              "additionalProperties": {
-                "$ref": "#/definitions/fields"
-              }
+              "$ref": "#/definitions/asset_contains"
             }
           }
         },
         {
-          "$ref": "#/definitions/stac_extensions"
+          "$comment": "This is the schema for the fields in Summaries. By default, only checks the existence of the properties, but not the schema of the summaries.",
+          "required": ["summaries"],
+          "properties": {
+            "summaries": {
+              "$ref": "#/definitions/require_any_field"
+            }
+          }
         }
       ]
     }
   ],
   "definitions": {
-    "stac_extensions": {
-      "type": "object",
-      "required": [
-        "stac_extensions"
-      ],
+    "assets": {
+      "required": ["assets"],
       "properties": {
-        "stac_extensions": {
-          "type": "array",
-          "contains": {
-            "contains": {
-              "const": "https://stac-extensions.github.io/view/v1.0.0/schema.json"
-            }
+        "assets": {
+          "$ref": "#/definitions/asset_contains"
+        }
+      }
+    },
+    "asset_contains": {
+      "type": "object",
+      "not": {
+        "additionalProperties": {
+          "not": {
+            "$ref": "#/definitions/requirements_and_fields"
           }
         }
       }
+    },
+    "requirements_and_fields": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/require_any_field"
+        },
+        {
+          "$ref": "#/definitions/fields"
+        }
+      ]
+    },
+    "require_any_field": {
+      "$comment": "Please list all fields here so that we can force the existence of one of them in other parts of the schemas.",
+      "anyOf": [
+        { "required": ["view:off_nadir"] },
+        { "required": ["view:incidence_angle"] },
+        { "required": ["view:azimuth"] },
+        { "required": ["view:sun_azimuth"] },
+        { "required": ["view:sun_elevation"] }
+      ]
     },
     "fields": {
       "$comment": "Add your new fields here. Don't require them here, do that above in the item schema.",
@@ -132,7 +145,9 @@
         }
       },
       "patternProperties": {
-        "^(?!view:)": {}
+        "^(?!view:)": {
+          "$comment": "Do not allow unspecified fields prefixed with view:"
+        }
       },
       "additionalProperties": false
     }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "stac-extensions",
+  "name": "stac-extension-view",
   "version": "1.0.0",
   "scripts": {
     "test": "npm run check-markdown && npm run check-examples",
@@ -8,13 +8,14 @@
     "format-examples": "stac-node-validator . --format --schemaMap https://stac-extensions.github.io/view/v1.0.0/schema.json=./json-schema/schema.json"
   },
   "dependencies": {
-    "remark-cli": "^8.0.0",
-    "remark-lint": "^7.0.0",
-    "remark-lint-no-html": "^2.0.0",
-    "remark-preset-lint-consistent": "^3.0.0",
-    "remark-preset-lint-markdown-style-guide": "^3.0.0",
-    "remark-preset-lint-recommended": "^4.0.0",
-    "remark-validate-links": "^10.0.0",
-    "stac-node-validator": "^1.0.0"
+    "remark-cli": "^12.0.0",
+    "remark-gfm": "^4.0.0",
+    "remark-lint": "^9.1.2",
+    "remark-lint-no-html": "^3.1.2",
+    "remark-preset-lint-consistent": "^5.1.2",
+    "remark-preset-lint-markdown-style-guide": "^5.1.3",
+    "remark-preset-lint-recommended": "^6.1.3",
+    "remark-validate-links": "^13.0.0",
+    "stac-node-validator": "^1.3.0"
   }
 }


### PR DESCRIPTION
Update extension to the current best practices for STAC extensions, allow fields in assets, don't require a field in Item Properties if it is provided in other places (e.g. assets)